### PR TITLE
feat:add-new-apps

### DIFF
--- a/buy/index.html
+++ b/buy/index.html
@@ -1057,7 +1057,7 @@ var log_object = {"ajax_url":"https:\/\/www.dash.org\/wp-admin\/admin-ajax.php"}
          "BTC",
          "ETH"
       ],
-      "image":"https://media.dash.org/wp-content/uploads/buy-thorswap.png",
+      "image":"https://media.dash.org/wp-content/uploads/thorswap.png",
       "url":"https://www.thorswap.finance/"
    },
 {
@@ -1073,7 +1073,7 @@ var log_object = {"ajax_url":"https:\/\/www.dash.org\/wp-admin\/admin-ajax.php"}
          "BTC",
          "ETH"
       ],
-      "image":"https://media.dash.org/wp-content/uploads/buy-thorwallet.png",
+      "image":"https://media.dash.org/wp-content/uploads/thorwallet1.png",
       "url":"https://www.thorwallet.org/"
    },
 {
@@ -1211,7 +1211,43 @@ var log_object = {"ajax_url":"https:\/\/www.dash.org\/wp-admin\/admin-ajax.php"}
       ],
       "image":"https://media.dash.org/wp-content/uploads/845b2219d0d24b999bb661c938e72455.avif",
       "url":"https://houdiniswap.com/"
-   }
+   },
+{
+   "name":"FlypMe",
+   "using":"traditional",
+   "type":"swap",
+   "instantsend":false,
+   "chainlocks":false,
+   "bti":true,
+   "confirmations":"1",
+   "currency":[
+      "USDT",
+      "BTC",
+      "ETH",
+      "LTC",
+      "etc"
+   ],
+   "image":"https://media.dash.org/wp-content/uploads/Flyp-me-logo.png",
+   "url":"https://flyp.me/"
+},
+{
+   "name":"Coin Swap",
+   "using":"traditional",
+   "type":"swap",
+   "instantsend":false,
+   "chainlocks":false,
+   "bti":true,
+   "confirmations":"1",
+   "currency":[
+      "USDT",
+      "BTC",
+      "ETH",
+      "LTC",
+      "etc"
+   ],
+   "image":"https://media.dash.org/wp-content/uploads/coin-swap-logo.png",
+   "url":"https://coinoswap.com/"
+},
 ]' inline-template>
 			<div v-cloak>
 


### PR DESCRIPTION
Logos changed
Added few new Swaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected vendor name spacing in the Buy & Spend list (“FlypMe” now displays without a leading space).
  - Confirmed no behavioral changes to the trading widget; display remains consistent.

- Style
  - Reformatted page markup and widget block indentation for consistency and readability. No impact on functionality or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->